### PR TITLE
fix: #19 consistent vuln count across auth/unauth requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@ Readme update
 - test: adds CDNjs scenario
 - fix: do not scan local modules
 - feat: decorate dependencies in package.json
+- fix: consistent vuln count across auth/unauth requests

--- a/src/getImports/testVuln.js
+++ b/src/getImports/testVuln.js
@@ -40,10 +40,14 @@ function testWithAuth(pkg) {
       ).replace(/\?.*$/, '');
 
       const vulns = res.data.vulnerabilities || [];
+
+      const uniqBasedOnId = new Set();
+      vulns.forEach(v => uniqBasedOnId.add(v.id));
+
       return {
         ...res.data,
         packageName,
-        count: vulns.length,
+        count: uniqBasedOnId.size,
         fixable: vulns.reduce((acc, curr) => {
           if (acc) return acc;
           if (curr.isUpgradable) return true;


### PR DESCRIPTION
The authenticated and unauthenticated requests hit different parts of our system which take slightly different approaches to vulnerabilities when they appear multiple times within a single package. The former counts each _instance_ of a vulnerability within a package, whereas the unauthenticated view will group these vulnerabilities based on a unique ID.

If you take a look at [this example](https://snyk.io/test/npm/express/3.0.0#npm:fresh:20170908) you can see appears multiple times as it has been introduced through 4 paths.