### PR TITLE
fix: Only show "click to fix" if a remediation is available

### DIFF
--- a/src/decorator.js
+++ b/src/decorator.js
@@ -47,8 +47,8 @@ function getDecorationMessage(packageInfo) {
     return '';
   }
 
-  const { count } = packageInfo.vulns;
-  let decorationMessage = `${count} vuln${count === 1 ? '' : 's'} (click to fix)`;
+  const { count, fixable } = packageInfo.vulns;
+  const decorationMessage = `${count} vuln${count === 1 ? '' : 's'}${fixable ? ' (click to fix)' : ''}`;
 
   return decorationMessage;
 }


### PR DESCRIPTION
As mentioned in #32 , "click to fix" is shown on all vulnerabilities, even ones that do not have a fix available:

![image](https://user-images.githubusercontent.com/19519564/94083648-b54dfa00-fdd1-11ea-89f1-534a1ae3cc7d.png)
![image](https://user-images.githubusercontent.com/19519564/94083797-0e1d9280-fdd2-11ea-9c99-94f83e0a7651.png)


This PR changes the behavior so that "click to fix" is only shown for fixable vulnerabilities