### PR TITLE
docs: Fix inline link to mongoDB contributor agreement (Typo fix)

### DIFF
--- a/Contributor-Agreement.md
+++ b/Contributor-Agreement.md
@@ -36,4 +36,4 @@ English law governs this Agreement, excluding any applicable conflict of laws ru
 
 **Agreed and accepted on my behalf and on behalf of my organization**
 
-Our contributor agreement is based on the [mongoDB contributor agreement] (https://www.mongodb.com/legal/contributor-agreement).
+Our contributor agreement is based on the [mongoDB contributor agreement](https://www.mongodb.com/legal/contributor-agreement).


### PR DESCRIPTION
A space between the closing bracket of the link display text and the open parenthesis of the link wrapper prevented the link from rendering correctly. This commit removes the space so the markdown link appears correctly.