### PR TITLE
feat: show deprecation notification [ROAD-333] [ROAD-332]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# Latest update 🗞️ (start here first 👇)
+Vuln Cost is no longer being actively maintained. While you can continue to use this extension until it is officially deprecated, we recommend you install the official Snyk extension. This new extension provides all the functionality supported by Vuln Cost and enables you to find and fix issues in both your open source dependencies AND your custom code.
+
 <p align="center"><a href="https://github.com/snyk/vulncost"><img src="https://raw.githubusercontent.com/snyk/vulncost/master/images/vuln_cost_logo_animated.gif" alt="Vuln Cost Animated Logo" height="60"/></a></p>
 <h1 align="center">Vuln Cost</h1>
 <p align="center">The world's easiest, Security Scanner for VS Code</p>
@@ -5,7 +8,7 @@
 <p align="center">
 	<a href="https://snyk.io/test/github/snyk/vulncost"><img src="https://snyk.io/test/github/snyk/vulncost/badge.svg"/></a>
   <a href="https://marketplace.visualstudio.com/items?itemName=snyk-security.vscode-vuln-cost"><img src="https://vsmarketplacebadge.apphb.com/installs-short/snyk-security.vscode-vuln-cost.svg"/></a>  <a href="https://marketplace.visualstudio.com/items?itemName=snyk-security.vscode-vuln-cost"><img alt="Visual Studio Marketplace Version" src="https://img.shields.io/visual-studio-marketplace/v/snyk-security.vscode-vuln-cost?label=Marketplace&logo=visual-studio-code"></a>
-	
+
 </p><br/><br/>
 
 <p align="center">


### PR DESCRIPTION
**Let's merge/release this only after GTM for the official extension.**

- Shows deprecation notification on monthly basis, similarly to what we had in DeepCode extension deprecation https://github.com/DeepCodeAI/vscode-extension/pull/87.
- Updates readme with deprecation note [ROAD-332]

![image](https://user-images.githubusercontent.com/2239563/141973158-dcc6e27b-e682-4331-b59d-3443f75e3cb8.png)


[ROAD-332]: https://snyksec.atlassian.net/browse/ROAD-332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ